### PR TITLE
fix #17

### DIFF
--- a/Sugo/AutomaticProperties.swift
+++ b/Sugo/AutomaticProperties.swift
@@ -22,24 +22,24 @@ class AutomaticProperties {
         let size = UIScreen.main.bounds.size
         let infoDict = Bundle.main.infoDictionary
         if let infoDict = infoDict {
-            p["$app_build_number"]     = infoDict["CFBundleVersion"]
-            p["$app_version_string"]   = infoDict["CFBundleShortVersionString"]
+            p["app_build_number"]     = infoDict["CFBundleVersion"]
+            p["app_version_string"]   = infoDict["CFBundleShortVersionString"]
         }
         #if os(iOS)
             p["$carrier"] = AutomaticProperties.telephonyInfo.subscriberCellularProvider?.carrierName
         #endif
         p["mp_lib"]             = "Swift"
-        p["$lib_version"]       = AutomaticProperties.libVersion()
-        p["$manufacturer"]      = "Apple"
-        p["$os"]                = UIDevice.current.systemName
-        p["$os_version"]        = UIDevice.current.systemVersion
-        p["$model"]             = AutomaticProperties.deviceModel()
-        p["$screen_height"]     = Int(size.height)
-        p["$screen_width"]      = Int(size.width)
+        p["lib_version"]       = AutomaticProperties.libVersion()
+        p["manufacturer"]      = "Apple"
+        p["os"]                = UIDevice.current.systemName
+        p["os_version"]        = UIDevice.current.systemVersion
+        p["model"]             = AutomaticProperties.deviceModel()
+        p["screen_height"]     = Int(size.height)
+        p["screen_width"]      = Int(size.width)
         return p
     }()
 
-    static var peopleProperties: InternalProperties = {
+    static var deviceProperties: InternalProperties = {
         var p = InternalProperties()
         let infoDict = Bundle.main.infoDictionary
         if let infoDict = infoDict {

--- a/Sugo/DecideRequest.swift
+++ b/Sugo/DecideRequest.swift
@@ -29,11 +29,11 @@ class DecideRequest: Network {
             self.distinctId = URLQueryItem(name: "distinct_id", value: distinctId)
 
             // workaround for a/b testing
-            var peoplePropertiesCopy = AutomaticProperties.peopleProperties
-            peoplePropertiesCopy["$ios_lib_version"] = "2.6"
+            var devicePropertiesCopy = AutomaticProperties.deviceProperties
+            devicePropertiesCopy["$ios_lib_version"] = AutomaticProperties.libVersion()
             // end of workaround
 
-            let propertiesData = try! JSONSerialization.data(withJSONObject: peoplePropertiesCopy)
+            let propertiesData = try! JSONSerialization.data(withJSONObject: devicePropertiesCopy)
             let propertiesString = String(data: propertiesData, encoding: String.Encoding.utf8)
             self.properties = URLQueryItem(name: "properties", value: propertiesString)
         }

--- a/Sugo/SugoInstance.swift
+++ b/Sugo/SugoInstance.swift
@@ -736,9 +736,9 @@ extension SugoInstance {
             self.time(event: "stay_event")
             var pViewController: Properties
             if let tittle = vc.title {
-                pViewController = ["stay_page": tittle]
+                pViewController = ["page": tittle]
             } else {
-                pViewController = ["stay_page": NSStringFromClass(vc.classForCoder)]
+                pViewController = ["page": NSStringFromClass(vc.classForCoder)]
             }
             self.track(eventName: "enter_page_event", properties: pViewController)
         }
@@ -755,9 +755,9 @@ extension SugoInstance {
             Logger.debug(message: "viewDidDisappear")
             var pViewController: Properties
             if let tittle = vc.title {
-                pViewController = ["stay_page": tittle]
+                pViewController = ["page": tittle]
             } else {
-                pViewController = ["stay_page": NSStringFromClass(vc.classForCoder)]
+                pViewController = ["page": NSStringFromClass(vc.classForCoder)]
             }
             self.track(eventName: "stay_event", properties: pViewController)
         }

--- a/Sugo/WebSocketWrapper.swift
+++ b/Sugo/WebSocketWrapper.swift
@@ -115,7 +115,7 @@ class WebSocketWrapper: WebSocketDelegate {
 
     func send(message: BaseWebSocketMessage?) {
         if connected {
-            Logger.debug(message: "Sending message: \(message.debugDescription)")
+//            Logger.debug(message: "Sending message: \(message.debugDescription)")
             if let data = message?.JSONData(), let jsonString = String(data: data, encoding: String.Encoding.utf8) {
                 webSocket.write(string: jsonString)
 //                Logger.debug(message: "Sent JSON:\n\(jsonString)")
@@ -124,7 +124,7 @@ class WebSocketWrapper: WebSocketDelegate {
     }
 
     class func getMessageType(for message: Data) -> BaseWebSocketMessage? {
-        Logger.info(message: "raw message \(message)")
+//        Logger.info(message: "raw message \(message)")
         var webSocketMessage: BaseWebSocketMessage? = nil
 //        Logger.debug(message: "Got Message:\n\(String(data: message, encoding: String.Encoding.utf8))")
         do {
@@ -237,7 +237,7 @@ class WebSocketWrapper: WebSocketDelegate {
         }
         if let messageData = text.data(using: String.Encoding.utf8) {
             let message = WebSocketWrapper.getMessageType(for: messageData)
-            Logger.info(message: "WebSocket received message: \(message.debugDescription)")
+//            Logger.info(message: "WebSocket received message: \(message.debugDescription)")
             if let commandOperation = message?.responseCommand(connection: self) {
                 commandQueue.addOperation(commandOperation)
                 if shouldShowUI {

--- a/Sugo/WebViewBindings+UIWebView.swift
+++ b/Sugo/WebViewBindings+UIWebView.swift
@@ -11,8 +11,7 @@ import JavaScriptCore
 
 extension WebViewBindings {
     
-    func bindUIWebView(webView: UIWebView) {
-        self.uiWebView = webView
+    func bindUIWebView(webView: inout UIWebView) {
         if !self.uiWebViewSwizzleRunning {
             let uiWebViewDidStartLoadBlock = {
                 [unowned self] (view: AnyObject?, command: Selector, webView: AnyObject?, param2: AnyObject?) in
@@ -40,7 +39,7 @@ extension WebViewBindings {
                     jsContext.evaluateScript(self.jsUIWebViewBindingsSource)
                     jsContext.evaluateScript(self.jsUIWebViewBindingsExcute)
                     self.uiWebViewJavaScriptInjected = true
-                    Logger.debug(message: "UIWebView Injected")
+//                    Logger.debug(message: "UIWebView Injected")
                 }
             }
             if let delegate = webView.delegate {
@@ -75,6 +74,7 @@ extension WebViewBindings {
             }
         }
     }
+    
 }
 
 extension UIWebView {

--- a/Sugo/WebViewBindings.swift
+++ b/Sugo/WebViewBindings.swift
@@ -23,7 +23,7 @@ class WebViewBindings: NSObject {
     var bindings: [[String: Any]]
     var uiVCPath: String
     var wkVCPath: String
-    var stringBindings: String
+    dynamic var stringBindings: String
     
     var viewSwizzleRunning = false
     
@@ -39,6 +39,8 @@ class WebViewBindings: NSObject {
     var wkWebViewJavaScriptInjected = false
     var wkDidMoveToWindowBlockName = UUID().uuidString
     var wkRemoveFromSuperviewBlockName = UUID().uuidString
+    lazy var wkWebViewCurrentJSSource = WKUserScript()
+    lazy var wkWebViewCurrentJSExcute = WKUserScript()
     
     static var global: WebViewBindings {
         return singleton
@@ -54,6 +56,9 @@ class WebViewBindings: NSObject {
         self.wkVCPath = String()
         self.stringBindings = String()
         super.init()
+        self.addObserver(self, forKeyPath: "stringBindings",
+                         options: NSKeyValueObservingOptions.new,
+                         context: nil)
     }
     
     func fillBindings() {
@@ -64,17 +69,13 @@ class WebViewBindings: NSObject {
         } else {
             self.bindings = [[String: Any]]()
         }
-        if !self.bindings.isEmpty {
-            do {
-                let jsonBindings = try JSONSerialization.data(withJSONObject: self.bindings,
-                                                              options: JSONSerialization.WritingOptions.prettyPrinted)
-                self.stringBindings = String(data: jsonBindings, encoding: String.Encoding.utf8)!
-            } catch {
-                Logger.debug(message: "Failed to serialize JSONObject: \(self.bindings)")
-            }
+        do {
+            let jsonBindings = try JSONSerialization.data(withJSONObject: self.bindings,
+                                                          options: JSONSerialization.WritingOptions.prettyPrinted)
+            self.stringBindings = String(data: jsonBindings, encoding: String.Encoding.utf8)!
+        } catch {
+            Logger.debug(message: "Failed to serialize JSONObject: \(self.bindings)")
         }
-        stop()
-        execute()
     }
 }
 


### PR DESCRIPTION
1. fix #17: Cannot bind current webviews' events immediately after switched to the codeless test mode
2. Remove “$” from properties' keys